### PR TITLE
Refactor doesUsernameExist to remove unnecessary .map

### DIFF
--- a/src/pages/sign-up.js
+++ b/src/pages/sign-up.js
@@ -20,7 +20,7 @@ export default function SignUp() {
     event.preventDefault();
 
     const usernameExists = await doesUsernameExist(username);
-    if (!usernameExists.length) {
+    if (!usernameExists) {
       try {
         const createdUserResult = await firebase
           .auth()

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -7,7 +7,7 @@ export async function doesUsernameExist(username) {
     .where('username', '==', username)
     .get();
 
-  return result.docs.map((user) => user.data().length > 0);
+  return result.docs.length > 0;
 }
 
 export async function getUserByUsername(username) {


### PR DESCRIPTION
Hey Karl, 

Made a small update. Some explanation -

#### How it worked before
- if user didn't exist then the `.map` would loop over `result.docs` (empty array) and return an empty array
- If user did exist then the `.map` would loop over `result.docs` which would check if `user.docs()` (which is a javascript ***object***) has length greater than 0 (always `false`) and return `[false]` 

So it worked but not exactly as expected 😅 and it seemed a bit confusing because of the naming

#### Changes
- Removed `map`, now there is a direct check in place to see if `result.docs` array has greater than 0 elements
    -   As a result `doesUsernameExist` will return a boolean
- Removed `.length` from the check because `usernameExists` should now be `true` or `false`

